### PR TITLE
Implemented clearHistory method to sdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/__tests__/sdb.test.js
+++ b/__tests__/sdb.test.js
@@ -141,6 +141,20 @@ describe("sdb#destroy()", () => {
   });
 });
 
+describe("sdb#clearHistory()", () => {
+  it("should not change by undo after clearHistory", () => {
+    sdb.fill("orange");
+    const url1 = sdb.toDataURL();
+
+    sdb.clearHistory();
+    sdb.undo();
+
+    const url2 = sdb.toDataURL();
+
+    expect(url1).toBe(url2);
+  });
+});
+
 describe("sdb#observer", () => {
   it("should expose", (done) => {
     sdb.observer.on("save", done);

--- a/src/sdb.js
+++ b/src/sdb.js
@@ -143,6 +143,10 @@ export class SimpleDrawingBoard {
     this._timer = null;
   }
 
+  clearHistory() {
+    this._history.clear();
+  }
+
   handleEvent(ev) {
     ev.preventDefault();
     ev.stopPropagation();


### PR DESCRIPTION
First, thank's to useful library :)

I implemented a history clear function in sdb to solve a problem that occurs during image editing use cases

In such a use case, sdb#fillImageByDataURL is called before the user action, but the process by sdb#fillImageByDataURL is recorded in the history. As a result, when the user performs a "back" operation implemented by sdb#undo(), a blank screen is displayed.

This problem can be solved by clearing the history in the case of editing, so this is why we have implemented it this way.